### PR TITLE
Allow overriding screenshotPath

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ module.exports = {
       return;
     }
 
-    const screenshotPath = await device.takeScreenshot(id);
+    const screenshotPath = options.screenshotPath || await device.takeScreenshot(id);
 
     await this._eyes.open(this._config.appName || 'APP_NAME_NOT_SET', id);
 


### PR DESCRIPTION
Allow overriding screenshotPath - this will allow to use the new [detox's elements' screenshots](https://github.com/wix/Detox/blob/master/docs/APIRef.Screenshots.md#element-level-screenshots-android-only) (and possibly other future features)