### PR TITLE
fix: add new parsing to device names

### DIFF
--- a/lib/detox.ts
+++ b/lib/detox.ts
@@ -1,5 +1,6 @@
 import {device} from 'detox';
 import {statusBarHeights, defaultHeight} from './status-bar';
+import extractDeviceName from './utils/extractDeviceName';
 
 export const getDeviceType = (): string => {
   return device.getPlatform();
@@ -17,17 +18,4 @@ export const getStatusBarHeight = (): number => {
 
 export const takeScreenshot = (name: string): Promise<string> => {
   return device.takeScreenshot(name) as unknown as Promise<string>;
-};
-
-const DEVICE_NAME_REGEXP = new RegExp(/\((.*?)\)/);
-
-const extractDeviceName = (fullDeviceName): string => {
-  const matches = fullDeviceName.match(DEVICE_NAME_REGEXP);
-
-  if (matches && matches.length === 2) {
-    return matches[1];
-  }
-
-  console.error('Could not parse device name', fullDeviceName);
-  return 'unknown';
 };

--- a/lib/utils/extractDeviceName.test.ts
+++ b/lib/utils/extractDeviceName.test.ts
@@ -1,0 +1,25 @@
+import extractDeviceName from './extractDeviceName';
+
+describe('extractDeviceName', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error');
+  });
+
+  test.each([
+    ['EB449DF0-39DC-457A-B2D7-25CE51BB1A2E (iPhone X)', 'iPhone X'],
+    ['EB449DF0-39DC-457A-B2D7-25CE51BB1A2E {"type": "iPhone 11"}', 'iPhone 11'],
+  ])('should parse %j to: %s', (input, expected) => {
+    expect(extractDeviceName(input)).toBe(expected);
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    [''],
+    ['booted ()', 'unknown'],
+    ['EB449DF0-39DC-457A-B2D7-25CE51BB1A2E {}', 'unknown'],
+    ['EB449DF0-39DC-457A-B2D7-25CE51BB1A2E {something: 42}}'],
+  ])('should identify %j as unknown and log an error', (input) => {
+    expect(extractDeviceName(input)).toBe('unknown');
+    expect(console.error).toHaveBeenCalledWith(expect.any(String), input);
+  });
+});

--- a/lib/utils/extractDeviceName.test.ts
+++ b/lib/utils/extractDeviceName.test.ts
@@ -1,13 +1,15 @@
 import extractDeviceName from './extractDeviceName';
 
+const TEST_UUID = 'EB449DF0-39DC-457A-B2D7-25CE51BB1A2E';
+
 describe('extractDeviceName', () => {
   beforeEach(() => {
     jest.spyOn(console, 'error');
   });
 
   test.each([
-    ['EB449DF0-39DC-457A-B2D7-25CE51BB1A2E (iPhone X)', 'iPhone X'],
-    ['EB449DF0-39DC-457A-B2D7-25CE51BB1A2E {"type": "iPhone 11"}', 'iPhone 11'],
+    [`${TEST_UUID} (iPhone X)`, 'iPhone X'],
+    [`${TEST_UUID} {"type": "iPhone 11"}`, 'iPhone 11'],
   ])('should parse %j to: %s', (input, expected) => {
     expect(extractDeviceName(input)).toBe(expected);
     expect(console.error).not.toHaveBeenCalled();
@@ -15,9 +17,9 @@ describe('extractDeviceName', () => {
 
   test.each([
     [''],
-    ['booted ()', 'unknown'],
-    ['EB449DF0-39DC-457A-B2D7-25CE51BB1A2E {}', 'unknown'],
-    ['EB449DF0-39DC-457A-B2D7-25CE51BB1A2E {something: 42}}'],
+    ['booted ()'],
+    [`${TEST_UUID} {}`],
+    [`${TEST_UUID} {some: 42}}`],
   ])('should identify %j as unknown and log an error', (input) => {
     expect(extractDeviceName(input)).toBe('unknown');
     expect(console.error).toHaveBeenCalledWith(expect.any(String), input);

--- a/lib/utils/extractDeviceName.ts
+++ b/lib/utils/extractDeviceName.ts
@@ -1,7 +1,7 @@
 const DEVICE_NAME_REGEXP_1 = new RegExp(/\((.*?)\)/);
 const DEVICE_NAME_REGEXP_2 = /^[0-9A-Fa-f-]{36}\s*(\{.*\})$/;
 
-export default function extractDeviceName(fullDeviceName: string): string {
+export default function extractDeviceName(fullDeviceName: string) {
   const result = extract1(fullDeviceName) || extract2(fullDeviceName);
   if (result) {
     return result;
@@ -11,15 +11,18 @@ export default function extractDeviceName(fullDeviceName: string): string {
   return 'unknown';
 }
 
-function extract1(fullDeviceName: string): string | undefined {
+function extract1(fullDeviceName: string) {
   const match = fullDeviceName.match(DEVICE_NAME_REGEXP_1);
   return match && match[1];
 }
 
-function extract2(fullDeviceName: string): string | undefined {
+function extract2(fullDeviceName: string) {
   const match = fullDeviceName.match(DEVICE_NAME_REGEXP_2);
+  const rawJson = match && match[1];
 
   try {
-    return JSON.parse(match[1]).type;
-  } catch (_e) { } // eslint-disable-line
+    return JSON.parse(rawJson).type;
+  } catch {
+    return undefined;
+  }
 }

--- a/lib/utils/extractDeviceName.ts
+++ b/lib/utils/extractDeviceName.ts
@@ -1,0 +1,25 @@
+const DEVICE_NAME_REGEXP_1 = new RegExp(/\((.*?)\)/);
+const DEVICE_NAME_REGEXP_2 = /^[0-9A-Fa-f-]{36}\s*(\{.*\})$/;
+
+export default function extractDeviceName(fullDeviceName: string): string {
+  const result = extract1(fullDeviceName) || extract2(fullDeviceName);
+  if (result) {
+    return result;
+  }
+
+  console.error('Could not parse device name', fullDeviceName);
+  return 'unknown';
+}
+
+function extract1(fullDeviceName: string): string | undefined {
+  const match = fullDeviceName.match(DEVICE_NAME_REGEXP_1);
+  return match && match[1];
+}
+
+function extract2(fullDeviceName: string): string | undefined {
+  const match = fullDeviceName.match(DEVICE_NAME_REGEXP_2);
+
+  try {
+    return JSON.parse(match[1]).type;
+  } catch (_e) { } // eslint-disable-line
+}

--- a/package.json
+++ b/package.json
@@ -5,13 +5,15 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "/dist"
+    "/dist",
+    "!*.test.js",
+    "!*.test.d.ts"
   ],
   "scripts": {
     "clean": "rm -rf dist",
     "build": "tsc",
     "pretest": "npm run build && npm run lint",
-    "test": ":",
+    "test": "jest",
     "lint": "eslint .",
     "prepublish": "npm run clean && npm run build"
   },
@@ -39,11 +41,13 @@
     "detox": "*"
   },
   "devDependencies": {
+    "@types/jest": "^27.0.2",
     "@types/node": "^14.14.35",
     "@typescript-eslint/eslint-plugin": "^4.19.0",
     "@typescript-eslint/parser": "^4.19.0",
     "eslint": "^7.22.0",
     "husky": "^5.2.0",
+    "jest": "^27.2.2",
     "lint-staged": "^10.5.4",
     "prettier": "^2.2.1",
     "typescript": "^4.2.3"
@@ -56,5 +60,14 @@
   "lint-staged": {
     "*.{js,ts}": "eslint --cache --fix",
     "*.{js,css,md,ts}": "prettier --write"
+  },
+  "jest": {
+    "resetMocks": true,
+    "testMatch": [
+      "<rootDir>/lib/**/*.test.ts"
+    ],
+    "transform": {
+      "\\.ts$": "ts-jest"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "detox-applitools-testing",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Utility to integrate applitools screenshot testing in your detox tests",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
I got tired of this message:

```
Could not parse device name EB449DF0-39DC-457A-B2D7-25CE51BB1A2E {"type":"iPhone 11"} 
```

So I added another strategy to parsing those device names.
The parsing function is now covered with a test suite.