### PR TITLE
fix: device name parsing backport from v2

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,15 +53,4 @@ module.exports = {
   }
 };
 
-const deviceNameRegExp = new RegExp(/\((.*?)\)/);
-
-const extractDeviceName = (fullDeviceName) => {
-  const matches = fullDeviceName.match(deviceNameRegExp);
-
-  if (matches && matches.length === 2) {
-    return matches[1];
-  }
-
-  console.error('Could not parse device name', fullDeviceName);
-  return 'unknown';
-}
+const extractDeviceName = require('./lib/utils/extractDeviceName');

--- a/lib/utils/extractDeviceName.js
+++ b/lib/utils/extractDeviceName.js
@@ -1,0 +1,39 @@
+const DEVICE_NAME_REGEXP_1 = new RegExp(/\((.*?)\)/);
+const DEVICE_NAME_REGEXP_2 = /^[0-9A-Fa-f-]{36}\s*(\{.*\})$/;
+
+/**
+ * @param {String} fullDeviceName
+ */
+function extractDeviceName(fullDeviceName) {
+  const result = extract1(fullDeviceName) || extract2(fullDeviceName);
+  if (result) {
+    return result;
+  }
+
+  console.error('Could not parse device name', fullDeviceName);
+  return 'unknown';
+}
+
+/**
+ * @param {String} fullDeviceName
+ */
+function extract1(fullDeviceName) {
+  const match = fullDeviceName.match(DEVICE_NAME_REGEXP_1);
+  return match && match[1];
+}
+
+/**
+ * @param {String} fullDeviceName
+ */
+function extract2(fullDeviceName) {
+  const match = fullDeviceName.match(DEVICE_NAME_REGEXP_2);
+  const rawJson = match && match[1];
+
+  try {
+    return JSON.parse(rawJson).type;
+  } catch {
+    return undefined;
+  }
+}
+
+module.exports = extractDeviceName;

--- a/lib/utils/extractDeviceName.test.js
+++ b/lib/utils/extractDeviceName.test.js
@@ -1,0 +1,27 @@
+const extractDeviceName = require('./extractDeviceName');
+
+const TEST_UUID = 'EB449DF0-39DC-457A-B2D7-25CE51BB1A2E';
+
+describe('extractDeviceName', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error');
+  });
+
+  test.each([
+    [`${TEST_UUID} (iPhone X)`, 'iPhone X'],
+    [`${TEST_UUID} {"type": "iPhone 11"}`, 'iPhone 11'],
+  ])('should parse %j to: %s', (input, expected) => {
+    expect(extractDeviceName(input)).toBe(expected);
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    [''],
+    ['booted ()'],
+    [`${TEST_UUID} {}`],
+    [`${TEST_UUID} {some: 42}}`],
+  ])('should identify %j as unknown and log an error', (input) => {
+    expect(extractDeviceName(input)).toBe('unknown');
+    expect(console.error).toHaveBeenCalledWith(expect.any(String), input);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Utility to integrate applitools screenshot testing in your detox tests",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -28,5 +28,14 @@
   },
   "peerDependencies": {
     "detox": "*"
+  },
+  "devDependencies": {
+    "jest": "^27.2.2"
+  },
+  "jest": {
+    "resetMocks": true,
+    "testMatch": [
+      "<rootDir>/lib/**/*.test.js"
+    ]
   }
 }


### PR DESCRIPTION
Before we get some free day or two to make an adapter between `v1` and `v2`, I thought it might be a good idea to backport:
https://github.com/wix-incubator/detox-applitools-testing/pull/4 from `v2`.